### PR TITLE
PERF: unsharpenedImage iterator in N4Bias...Filter is now "WithIndex"

### DIFF
--- a/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
+++ b/Modules/Filtering/BiasCorrection/include/itkN4BiasFieldCorrectionImageFilter.hxx
@@ -24,6 +24,7 @@
 #include "itkBSplineControlPointImageFilter.h"
 #include "itkDivideImageFilter.h"
 #include "itkExpImageFilter.h"
+#include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImportImageFilter.h"
@@ -242,7 +243,7 @@ N4BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   RealType binMaximum = NumericTraits<RealType>::NonpositiveMin();
   RealType binMinimum = NumericTraits<RealType>::max();
 
-  ImageRegionConstIterator<RealImageType> ItU(
+  ImageRegionConstIteratorWithIndex<RealImageType> ItU(
     unsharpenedImage, unsharpenedImage->GetLargestPossibleRegion() );
 
   for( ItU.GoToBegin(); !ItU.IsAtEnd(); ++ItU )


### PR DESCRIPTION
Declared the unsharpenedImage iterator within N4BiasFieldCorrectionImageFilter::SharpenImage as ImageRegionConstIteratorWithIndex, instead of ImageRegionConstIterator.

Observed a significant performance improvement: 10% to 30% reduction of runtime duration on filter->Update().
